### PR TITLE
Upgrade of mockito 1.7 en 1.9.0

### DIFF
--- a/codjo-administration-server/src/test/resources/net/codjo/administration/server/dependencyTest.txt
+++ b/codjo-administration-server/src/test/resources/net/codjo/administration/server/dependencyTest.txt
@@ -11,7 +11,7 @@ net.codjo.administration.server.audit.mad
 	-> net.codjo.security.common.api
 	-> net.codjo.test.common
 	-> org.mockito
-	-> org.mockito.internal.progress
+	-> org.mockito.stubbing
 
 net.codjo.administration.server.audit.memory
 	-> net.codjo.agent.test
@@ -59,4 +59,4 @@ net.codjo.administration.server.plugin
 	-> net.codjo.plugin.server
 	-> net.codjo.test.common
 	-> org.mockito
-	-> org.mockito.internal.progress
+	-> org.mockito.stubbing


### PR DESCRIPTION
### Context

Need the use of `Mockito.doCallRealMethod` (start to be present in version 1.8 of `mockito`).
### Description

The version has been upgraded to the last version: `1.9.0`.
This implies the replacement in `DepedencyTest` tests of: 
`-> org.mockito.internal.progress`
by:
`-> org.mockito.stubbing`
