### PR TITLE
Improves GUI layout and labels for audit of SQL queries

### DIFF
--- a/codjo-administration-gui/src/main/java/net/codjo/administration/gui/plugin/ConfigurationPanel.form
+++ b/codjo-administration-gui/src/main/java/net/codjo/administration/gui/plugin/ConfigurationPanel.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="net.codjo.administration.gui.plugin.ConfigurationPanel">
-  <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="8" column-count="6" same-size-horizontally="false" same-size-vertically="false" hgap="10" vgap="10">
+  <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="7" column-count="8" same-size-horizontally="false" same-size-vertically="false" hgap="10" vgap="10">
     <margin top="10" left="20" bottom="10" right="10"/>
     <constraints>
       <xy x="20" y="20" width="800" height="400"/>
@@ -12,7 +12,7 @@
     <children>
       <vspacer id="8eb88">
         <constraints>
-          <grid row="6" column="0" row-span="2" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+          <grid row="5" column="0" row-span="2" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
             <preferred-size width="11" height="87"/>
           </grid>
         </constraints>
@@ -42,7 +42,7 @@
       </component>
       <hspacer id="14898">
         <constraints>
-          <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false">
+          <grid row="0" column="2" row-span="1" col-span="2" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false">
             <minimum-size width="20" height="-1"/>
           </grid>
         </constraints>
@@ -80,7 +80,7 @@
       </component>
       <component id="18c0c" class="javax.swing.JTextField" binding="directoryLog">
         <constraints>
-          <grid row="1" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="1" row-span="1" col-span="3" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <editable value="true"/>
@@ -91,7 +91,7 @@
       </component>
       <component id="9b8ea" class="javax.swing.JButton" binding="applyButton">
         <constraints>
-          <grid row="1" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="6" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <enabled value="false"/>
@@ -104,7 +104,7 @@
       </component>
       <component id="1517" class="javax.swing.JButton" binding="resetButton">
         <constraints>
-          <grid row="1" column="5" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="7" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <enabled value="true"/>
@@ -118,7 +118,7 @@
       </component>
       <component id="18cc9" class="javax.swing.JButton" binding="undoButton">
         <constraints>
-          <grid row="1" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="5" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <borderPainted value="true"/>
@@ -139,7 +139,7 @@
           <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
-          <text value="Audit des requêtes"/>
+          <text value="Audit des requêtes SQL"/>
         </properties>
       </component>
       <component id="50d61" class="javax.swing.JButton" binding="recordJdbcStatisticsButton">
@@ -157,17 +157,9 @@
           <text value=""/>
         </properties>
       </component>
-      <component id="df7fd" class="javax.swing.JLabel" binding="jdbcUsersFilterLabel">
-        <constraints>
-          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text value="Audit des requêtes pour les utilisateurs suivants"/>
-        </properties>
-      </component>
       <component id="974a8" class="javax.swing.JTextField" binding="jdbcUsersFilter">
         <constraints>
-          <grid row="5" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <editable value="true"/>
@@ -176,9 +168,17 @@
           <text value=""/>
         </properties>
       </component>
+      <component id="df7fd" class="javax.swing.JLabel" binding="jdbcUsersFilterLabel">
+        <constraints>
+          <grid row="4" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value=" restreint aux utilisateurs suivants :"/>
+        </properties>
+      </component>
       <component id="7faa3" class="javax.swing.JButton" binding="undoJdbcButton">
         <constraints>
-          <grid row="5" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="5" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <borderPainted value="true"/>
@@ -196,7 +196,7 @@
       </component>
       <component id="6e403" class="javax.swing.JButton" binding="applyJdbcButton">
         <constraints>
-          <grid row="5" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="6" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <enabled value="false"/>
@@ -209,7 +209,7 @@
       </component>
       <component id="6825" class="javax.swing.JButton" binding="resetJdbcButton">
         <constraints>
-          <grid row="5" column="5" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="7" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <enabled value="true"/>

--- a/codjo-administration-gui/src/main/resources/net/codjo/administration/gui/i18n.properties
+++ b/codjo-administration-gui/src/main/resources/net/codjo/administration/gui/i18n.properties
@@ -22,8 +22,8 @@ ConfigurationPanel.resetButton.tooltip=Recharger la configuration statique
 SystemPropertiesPanel.systemPropertiesPanel.title=Propriétés système
 SystemPropertiesPanel.environmentPanel.title=Environnement
 
-ConfigurationPanel.jdbcAuditLabel=Audit des requêtes
-ConfigurationPanel.jdbcUsersFilterLabel=Audit des requêtes pour les utilisateurs suivants
+ConfigurationPanel.jdbcAuditLabel=Audit des requêtes SQL
+ConfigurationPanel.jdbcUsersFilterLabel=restreint aux utilisateurs suivants :
 ConfigurationPanel.recordJdbcStatisticsButton.activate.tooltip=Activer
 ConfigurationPanel.recordJdbcStatisticsButton.deactivate.tooltip=Désactiver
 ConfigurationPanel.undoJdbcButton.tooltip=Annuler la saisie

--- a/codjo-administration-gui/src/main/resources/net/codjo/administration/gui/i18n_en.properties
+++ b/codjo-administration-gui/src/main/resources/net/codjo/administration/gui/i18n_en.properties
@@ -22,8 +22,8 @@ ConfigurationPanel.recordHandlerStatisticsButton.deactivate.tooltip=Suspend
 ConfigurationPanel.recordMemoryUsageButton.activate.tooltip=Activate
 ConfigurationPanel.recordMemoryUsageButton.deactivate.tooltip=Suspend
 
-ConfigurationPanel.jdbcAuditLabel=Queries Audit
-ConfigurationPanel.jdbcUsersFilterLabel=Queries Audit for following users
+ConfigurationPanel.jdbcAuditLabel=SQL Queries Audit
+ConfigurationPanel.jdbcUsersFilterLabel=restricted to following users :
 ConfigurationPanel.recordJdbcStatisticsButton.activate.tooltip=Activate
 ConfigurationPanel.recordJdbcStatisticsButton.deactivate.tooltip=Suspend
 ConfigurationPanel.undoJdbcButton.tooltip=Undo


### PR DESCRIPTION
## Context

During meeting for the previous stabilisation, there were some remarks about GUI layout and labels for audit of SQL queries.
## Description
- Replaces `jdbc queries` by `SQL queries` in labels.
- The button to activate/desactivate the service and the filter field are now in the same line.
