### PR TITLE
Impacts due to move of the Statistics class from codjo-sql to codjo-util

### DIFF
--- a/codjo-administration-server/src/main/java/net/codjo/administration/server/audit/AbstractExecutionSpy.java
+++ b/codjo-administration-server/src/main/java/net/codjo/administration/server/audit/AbstractExecutionSpy.java
@@ -54,7 +54,7 @@ abstract public class AbstractExecutionSpy {
 
         protected final void logBd(ConnectionSpy connectionSpy) {
             for (OneQuery query : connectionSpy.getAllQueries()) {
-                log(type, "Temps BD", query.getWhen(), query.getSql(), query.getCount(), query.getTime() + " ms");
+                log(type, "Temps BD", query.getWhen(), query.getSql(), query.getCount(), query.getTotalTime() + " ms");
             }
         }
 

--- a/codjo-administration-server/src/main/java/net/codjo/administration/server/audit/jdbc/JdbcExecutionSpy.java
+++ b/codjo-administration-server/src/main/java/net/codjo/administration/server/audit/jdbc/JdbcExecutionSpy.java
@@ -85,7 +85,7 @@ public class JdbcExecutionSpy extends AbstractExecutionSpy implements Connection
 
         Comparator<OneQuery> comparator = new Comparator<OneQuery>() {
             public int compare(OneQuery o1, OneQuery o2) {
-                int result = (int)(o1.getTime() - o2.getTime());
+                int result = (int)(o1.getTotalTime() - o2.getTotalTime());
                 return -result; // reverse order (=max time first)
             }
         };
@@ -100,7 +100,7 @@ public class JdbcExecutionSpy extends AbstractExecutionSpy implements Connection
                                                    applicationUser,
                                                    query.getMinTime(),
                                                    query.getMaxTime(),
-                                                   query.getTime(),
+                                                   query.getTotalTime(),
                                                    query.getCount(),
                                                    query.getSql());
             order++;

--- a/codjo-administration-server/src/test/java/net/codjo/administration/server/audit/jdbc/JdbcExecutionSpyTest.java
+++ b/codjo-administration-server/src/test/java/net/codjo/administration/server/audit/jdbc/JdbcExecutionSpyTest.java
@@ -19,8 +19,8 @@ import net.codjo.administration.server.operation.configuration.QueryPlan;
 import net.codjo.sql.server.ConnectionPool;
 import net.codjo.sql.server.ConnectionPoolFactory;
 import net.codjo.sql.spy.ConnectionSpy;
-import net.codjo.sql.spy.stats.Statistics;
 import net.codjo.util.time.MockTimeSource;
+import net.codjo.util.time.Statistics;
 import org.apache.log4j.Logger;
 import org.junit.Test;
 import org.junit.experimental.theories.DataPoint;
@@ -273,7 +273,8 @@ public class JdbcExecutionSpyTest extends AbstractJdbcExecutionSpyTest {
                                              Statistics queryStats, String user) {
         assertLinePresent(lines,
                           "write(JDBC, Aggregated statistics, " + order + ", " + user +
-                          ", " + queryStats.getMinTime() + ", " + queryStats.getMaxTime() + ", " + queryStats.getTime()
+                          ", " + queryStats.getMinTime() + ", " + queryStats.getMaxTime() + ", "
+                          + queryStats.getTotalTime()
                           +
                           ", " + queryStats.getCount() + ", " + query + ")",
                           false,
@@ -290,7 +291,7 @@ public class JdbcExecutionSpyTest extends AbstractJdbcExecutionSpyTest {
                           "write\\(JDBC, Temps BD, " + expectedDateString + ", " + expectedSpyId + ", " + USER1 + ", "
                           + escapeRegExpChars(query)
                           + ", "
-                          + queryStats.getCount() + ", " + queryStats.getTime() + " ms\\)",
+                          + queryStats.getCount() + ", " + queryStats.getTotalTime() + " ms\\)",
                           true,
                           errors);
     }

--- a/codjo-administration-server/src/test/java/net/codjo/administration/server/operation/configuration/AdministrationServerConfigurationAgentTest.java
+++ b/codjo-administration-server/src/test/java/net/codjo/administration/server/operation/configuration/AdministrationServerConfigurationAgentTest.java
@@ -754,11 +754,7 @@ public class AdministrationServerConfigurationAgentTest {
                                      final String user,
                                      final Query... queries) {
         final MockTimeSource timeSource = new MockTimeSource();
-        story.record().addAction(new AgentContainerFixture.Runnable() {
-            public void run() throws Exception {
-                new ConnectionAction(logFile, user, timeSource, queries).call();
-            }
-        });
+        story.record().addAction(new ConnectionAction(logFile, user, timeSource, queries));
     }
 
 

--- a/codjo-administration-server/src/test/java/net/codjo/administration/server/operation/configuration/ConnectionAction.java
+++ b/codjo-administration-server/src/test/java/net/codjo/administration/server/operation/configuration/ConnectionAction.java
@@ -6,11 +6,11 @@ import java.sql.Statement;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.TreeSet;
-import java.util.concurrent.Callable;
 import net.codjo.administration.server.AbstractJdbcExecutionSpyTest;
 import net.codjo.administration.server.audit.AdministrationLogFile;
 import net.codjo.administration.server.audit.jdbc.JdbcExecutionSpy;
 import net.codjo.agent.UserId;
+import net.codjo.agent.test.AgentContainerFixture;
 import net.codjo.mad.common.Log;
 import net.codjo.sql.server.ConnectionPool;
 import net.codjo.sql.server.ConnectionPoolConfiguration;
@@ -20,7 +20,7 @@ import org.apache.log4j.Logger;
 /**
  *
  */
-public class ConnectionAction implements Callable<Object> {
+public class ConnectionAction implements AgentContainerFixture.Runnable {
     private static final Logger LOG = Logger.getLogger(ConnectionAction.class);
 
     private final AdministrationLogFile logFile;
@@ -38,7 +38,7 @@ public class ConnectionAction implements Callable<Object> {
     }
 
 
-    public final Object call() throws Exception {
+    public final void run() throws Exception {
         try {
             // simulate some activity
             String password = "password";
@@ -81,8 +81,6 @@ public class ConnectionAction implements Callable<Object> {
             Log.error(e.getMessage(), e);
             throw e;
         }
-
-        return null;
     }
 
 

--- a/codjo-administration-server/src/test/java/net/codjo/administration/server/operation/configuration/QueryPlan.java
+++ b/codjo-administration-server/src/test/java/net/codjo/administration/server/operation/configuration/QueryPlan.java
@@ -2,7 +2,8 @@ package net.codjo.administration.server.operation.configuration;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Set;
 import java.util.TreeSet;
-import net.codjo.sql.spy.stats.Statistics;
+import net.codjo.util.time.SimpleStatistics;
+import net.codjo.util.time.Statistics;
 /**
  *
  */
@@ -26,13 +27,12 @@ public class QueryPlan {
 
     public Statistics computeStats(String query1, Integer connectionId)
           throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
-        Statistics result = new Statistics();
+        SimpleStatistics result = new SimpleStatistics();
 
         for (int i = 0; i < queries.length; i++) {
             Query query = queries[i];
             if (query.getQuery().equals(query1) && ((connectionId == null) || (connectionId.intValue()
                                                                                == query.connectionId))) {
-                result.inc();
                 result.addTime(queries[i].getTime());
             }
         }

--- a/codjo-administration-server/src/test/resources/net/codjo/administration/server/dependencyTest.txt
+++ b/codjo-administration-server/src/test/resources/net/codjo/administration/server/dependencyTest.txt
@@ -15,7 +15,6 @@ net.codjo.administration.server.audit.jdbc
 	-> net.codjo.administration.server.operation.configuration
 	-> net.codjo.sql.server
 	-> net.codjo.sql.spy
-	-> net.codjo.sql.spy.stats
 	-> net.codjo.test.common
 	-> net.codjo.util.time
 
@@ -50,7 +49,6 @@ net.codjo.administration.server.operation.configuration
 	-> net.codjo.mad.server.handler
 	-> net.codjo.mad.server.plugin
 	-> net.codjo.sql.server
-	-> net.codjo.sql.spy.stats
 	-> net.codjo.test.common
 	-> net.codjo.util.time
 	-> org.apache.commons.lang


### PR DESCRIPTION
## Context

This library was using the `Statistics` class, which has been moved from `codjo-sql` to `codjo-util`.
## Description

The impacts on this library are now fixed.
