### PR TITLE
Fix a deadlock in audit screens

### DIFF
--- a/codjo-administration-gui/src/test/java/net/codjo/administration/gui/plugin/AdministrationGuiTest.java
+++ b/codjo-administration-gui/src/test/java/net/codjo/administration/gui/plugin/AdministrationGuiTest.java
@@ -1,5 +1,6 @@
 package net.codjo.administration.gui.plugin;
 import javax.swing.JButton;
+import javax.swing.SwingUtilities;
 import net.codjo.administration.common.ConfigurationOntology;
 import net.codjo.administration.gui.AdministrationGuiContext;
 import net.codjo.gui.toolkit.waiting.WaitingPanel;
@@ -73,6 +74,13 @@ public class AdministrationGuiTest extends UISpecTestCase {
         gui.lockGui();
         gui.unlockGui();
         gui.unlockGui();
+
+        // The following empty task will be processed
+        // after lockGui and unlockGui have finished their work in EDT.
+        SwingUtilities.invokeAndWait(new Runnable() {
+            public void run() {
+            }
+        });
 
         log.assertContent("startAnimation(), stopAnimation()");
     }


### PR DESCRIPTION
## Context

A deadlock sometimes happened while doing these steps in an application :
1 - clic on menu Audit > Logs (workflow logs)
2 - clic on menu Audit > Server administration
## Description

The deadlock has been fixed by managing GUI lock/unlock in the Event Dispatch Thread (which removes the need of synchronization).
